### PR TITLE
Fixed Dockerfile for storage-temp

### DIFF
--- a/storage-temp/Dockerfile
+++ b/storage-temp/Dockerfile
@@ -1,6 +1,6 @@
 FROM openstf/stf:latest
 
 USER root
-RUN mkdir /data && chown stf:stf /data
+RUN mkdir data && chown stf:stf data
 USER stf
-VOLUME ["/data"]
+VOLUME ["data"]


### PR DESCRIPTION
Hello,

drag and drop to install apk did not work in you solution. I've changed the location of the directory named "data" in the Dockerfile for storage-temp so it coincides with the directory location in the docker-compose file. This fixes apk drag-and-drop feature.
